### PR TITLE
mv sorting to api call, fix sorting, tidy table

### DIFF
--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -31,7 +31,7 @@ function renderStatus(event: any) {
         href={pathcat("https://spanner.wwlrc.co.uk", "/rallies/r/:id", event)}
         target="_blank"
       >
-        <button className="px-2 py-2 bg-blue-600 text-white font-bold rounded-lg text-sm">
+        <button className="px-2 py-1 bg-blue-600 text-white font-bold rounded-lg text-sm">
           Opening Soon
         </button>
       </a>
@@ -44,7 +44,7 @@ function renderStatus(event: any) {
         href={pathcat("https://spanner.wwlrc.co.uk", "/rallies/r/:id", event)}
         target="_blank"
       >
-        <button className="px-2 py-2 bg-red-600 text-white font-bold rounded-lg text-sm">
+        <button className="px-2 py-1 bg-red-600 text-white font-bold rounded-lg text-sm">
           Bookings Closed
         </button>
       </a>
@@ -57,7 +57,7 @@ function renderStatus(event: any) {
         href={pathcat("https://spanner.wwlrc.co.uk", "/rallies/r/:id", event)}
         target="_blank"
       >
-        <button className="px-2 py-2 bg-green-600 text-white font-bold rounded-lg hover:bg-green-200">
+        <button className="px-2 py-1 bg-green-600 text-white font-bold rounded-lg text-sm hover:bg-green-200">
           Book Now
         </button>
       </a>
@@ -140,10 +140,10 @@ export default function SpannerCalendar({ staticEvents }: any) {
                   );
                 }}
               >
-                <td className="px-2 py-1 md:px-4 md:py-2 border border-solid border-gray-200 dark:border-gray-600 hidden md:table-cell">
+                <td className="px-2 py-2 md:px-4 md:py-3 border border-solid border-gray-200 dark:border-gray-600 hidden md:table-cell">
                   {renderDate(event)}
                 </td>
-                <td className="px-2 py-1 md:px-4 md:py-2 border border-solid border-gray-200 dark:border-gray-600">
+                <td className="px-2 py-2 md:px-4 md:py-3 border border-solid border-gray-200 dark:border-gray-600">
                   <p className="md:hidden">
                     <strong>{renderDate(event)}</strong>
                   </p>
@@ -152,7 +152,7 @@ export default function SpannerCalendar({ staticEvents }: any) {
                 <td className="px-2 py-1 md:px-4 md:py-2 border border-solid border-gray-200 dark:border-gray-600 text-center">
                   {renderStatus(event)}
                 </td>
-                <td className="px-2 py-1 md:px-4 md:py-2 border border-solid border-gray-200 dark:border-gray-600 hidden md:table-cell">
+                <td className="px-2 py-2 md:px-4 md:py-3 border border-solid border-gray-200 dark:border-gray-600 hidden md:table-cell">
                   {renderLocation(event.location)}
                 </td>
               </tr>

--- a/src/components/calendar.tsx
+++ b/src/components/calendar.tsx
@@ -71,12 +71,6 @@ function renderLocation(location: any) {
   return location.name + " (" + location.postcode + ")";
 }
 
-function cmpEvents(a: any, b: any): boolean {
-  a = new Date(a.start_date);
-  b = new Date(b.start_date);
-  return a > b;
-}
-
 export default function SpannerCalendar({ staticEvents }: any) {
   // Remove all event status data to avoid an event being shown
   // as still open, when it is actually closed
@@ -84,13 +78,11 @@ export default function SpannerCalendar({ staticEvents }: any) {
     event.bookings_status = "not-known";
     return event;
   });
-  staticEvents.sort(cmpEvents);
 
   const [events, setEvents] = useState(staticEvents);
 
   const updateEvents = () => {
     getEvents().then((events) => {
-      events.sort(cmpEvents);
       setEvents(events);
     });
   };

--- a/src/spanner/events.ts
+++ b/src/spanner/events.ts
@@ -1,6 +1,14 @@
 export async function getEvents() {
-    let res = await fetch('https://spanner.wwlrc.co.uk/api/clubs/c/2/rallies?size=100&page=0&sorts[start_date]=desc')
-    let data = await res.json()
-    
-    return data.rows
+  let res = await fetch(
+    "https://spanner.wwlrc.co.uk/api/clubs/c/2/rallies?size=25&page=0&sorts[start_date]=desc",
+  );
+  let data = await res.json();
+
+  let events = data.rows.sort(function (a: any, b: any): number {
+    let aStartDate = new Date(a.start_date);
+    let bStartDate = new Date(b.start_date);
+    return aStartDate.getTime() - bStartDate.getTime();
+  });
+
+  return events;
 }

--- a/src/spanner/events.ts
+++ b/src/spanner/events.ts
@@ -4,7 +4,8 @@ export async function getEvents() {
   );
   let data = await res.json();
 
-  let events = data.rows.sort(function (a: any, b: any): number {
+  let events = data.rows != undefined ? data.rows : [];
+  events.sort(function (a: any, b: any): number {
     let aStartDate = new Date(a.start_date);
     let bStartDate = new Date(b.start_date);
     return aStartDate.getTime() - bStartDate.getTime();


### PR DESCRIPTION
Turned out to be a nice little js implementation detail.

[`Array.sort()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) expects an integer return, and I was returning a boolean. Firefox dealt with this gracefully, whilst nodejs just refused to sort the array.